### PR TITLE
Add basic cldmemory demo in TEST folder

### DIFF
--- a/TEST/README.md
+++ b/TEST/README.md
@@ -1,0 +1,5 @@
+# TEST Examples
+
+This folder provides a minimal example of how to integrate the **cldmemory** package.
+
+Run the script with `npm run ts-node` or `npx tsx` if you have the dependencies installed.

--- a/TEST/demo.ts
+++ b/TEST/demo.ts
@@ -1,0 +1,28 @@
+import { MemoryService } from '../src/services/memory';
+import { MemoryType } from '../src/types/memory';
+
+async function main() {
+  const service = new MemoryService();
+  await service.initialize();
+
+  // Create a memory entry
+  const memory = await service.createMemory(
+    'Toto je pouze testovací ukázka pro složku TEST.',
+    MemoryType.EPISODIC,
+    { tags: ['test'] },
+    0.7,
+    'Ukázková paměť'
+  );
+  console.log('Vytvořena paměť:', memory.id);
+
+  // Search for it
+  const results = await service.searchMemories({
+    query: 'testovací',
+    limit: 5,
+  });
+  console.log('Nalezené výsledky:', results.map(r => r.id));
+}
+
+main().catch(err => {
+  console.error('Chyba během ukázky:', err);
+});


### PR DESCRIPTION
## Summary
- add a new `TEST` folder
- provide a simple demo script using `MemoryService`
- include a README with instructions

## Testing
- `npm run lint` *(fails: couldn't find ESLint config)*
- `npm run typecheck` *(fails: missing modules)*
- `npm run build` *(fails: missing modules)*
- `npm install` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_684c1c0ef754833097db19e4d7d3f10e