### PR TITLE
Fix MemoryService constructor usage in tests

### DIFF
--- a/tests/edge-case-tests.ts
+++ b/tests/edge-case-tests.ts
@@ -1,17 +1,13 @@
 import { MemoryService } from '../src/services/memory';
-import { QdrantService } from '../src/services/qdrant';
-import { OpenAIService } from '../src/services/openai';
 import { MemoryType } from '../src/types/memory';
 
 async function runEdgeCaseTests() {
-  const qdrant = new QdrantService();
-  const openai = new OpenAIService();
-  const memoryService = new MemoryService(qdrant, openai);
+  const memoryService = new MemoryService();
 
   console.log('🧪 Starting Memory System Edge Case Tests...\n');
 
   // Initialize Qdrant
-  await qdrant.initialize();
+  await memoryService.initialize();
 
   // Test 1: Empty/Null Content
   console.log('📝 Test 1: Empty/Null Content Handling');

--- a/tests/run-edge-tests.ts
+++ b/tests/run-edge-tests.ts
@@ -1,15 +1,11 @@
 import { MemoryService } from '../src/services/memory';
-import { QdrantService } from '../src/services/qdrant';
-import { OpenAIService } from '../src/services/openai';
 import { MemoryType } from '../src/types/memory';
 
 async function testEdgeCases() {
-  const qdrant = new QdrantService();
-  const openai = new OpenAIService();
-  const memoryService = new MemoryService(qdrant, openai);
+  const memoryService = new MemoryService();
 
   console.log('Initializing Qdrant...');
-  await qdrant.initialize();
+  await memoryService.initialize();
 
   // Test 1: Empty content validation
   console.log('\n=== Test 1: Empty Content Validation ===');


### PR DESCRIPTION
## Summary
- update edge case and run-edge-tests to use default MemoryService constructor

## Testing
- `npm test` *(fails: tsx not found)*
- `npm run lint` *(fails: ESLint config missing)*
- `npm run typecheck` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_684c1e2a384483309da033bdf7d3be0a